### PR TITLE
Enable sloccount plugin for maven jobs

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/SloccountDescriptor.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountDescriptor.java
@@ -3,6 +3,7 @@ package hudson.plugins.sloccount;
 import hudson.Extension;
 import hudson.maven.AbstractMavenProject;
 import hudson.model.AbstractProject;
+import hudson.model.FreeStyleProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 
@@ -18,7 +19,7 @@ public class SloccountDescriptor extends BuildStepDescriptor<Publisher> {
     }
 
     public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-        return !AbstractMavenProject.class.isAssignableFrom(jobType);
+        return AbstractMavenProject.class.isAssignableFrom(jobType) || FreeStyleProject.class.isAssignableFrom(jobType);
     }
 
     @Override


### PR DESCRIPTION
According to wiki (https://wiki.jenkins-ci.org/display/JENKINS/SLOCCount+Plugin),
SLOCCount plugin can be used with M2 Extra Build,
but SLOCCount plugin is not enabled for Maven jobs.
This pull request enables the plugin for Maven jobs.
