### PR TITLE
[FIXED JENKINS-14255] java.io.InvalidClassException

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/SloccountPublisher.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountPublisher.java
@@ -46,33 +46,32 @@ public class SloccountPublisher extends Recorder implements Serializable {
 
     @Override
     public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener){
-       
+          
         SloccountResult result;
             
+        FilePath workspace = build.getWorkspace();
         PrintStream logger = listener.getLogger();
-        SloccountReport report = new SloccountReport();
-        SloccountParser parser = new SloccountParser(this.getRealEncoding(), this.getRealPattern(), logger, report);
+        SloccountParser parser = new SloccountParser(this.getRealEncoding(), this.getRealPattern(), logger);
+        SloccountReport report;
 
-        if(this.canContinue(build.getResult())){
-            
-            try{
-                FilePath workspace = build.getWorkspace();
+        try{
+            if(this.canContinue(build.getResult())){
                 report = workspace.act(parser);
-
-            }catch(IOException ioe){
-                ioe.printStackTrace(logger);
-                return false;
-
-            }catch(InterruptedException ie){
-                ie.printStackTrace(logger);
-                return false;
+            }else{
+                // generate an empty report
+                // TODO: Replace this empty report with the last valid one?
+                report = new SloccountReport();
             }
             
-        }else{
-            
-            // continue with empty report object
+        }catch(IOException ioe){
+            ioe.printStackTrace(logger);
+            return false;
+
+        }catch(InterruptedException ie){
+            ie.printStackTrace(logger);
+            return false;
         }
-  
+
         result = new SloccountResult(report, build);
         
         SloccountBuildAction buildAction = new SloccountBuildAction(build, result);

--- a/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
+++ b/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
@@ -21,10 +21,8 @@ public class SloccountParser implements FilePath.FileCallable<SloccountReport> {
     private final String encoding;
     private final String filePattern;
     private transient PrintStream logger = null;
-    private transient SloccountReport report = null;
 
-    public SloccountParser(String encoding, String filePattern, PrintStream logger, SloccountReport report){
-        this.report = report;
+    public SloccountParser(String encoding, String filePattern, PrintStream logger){
         this.logger = logger;
         this.filePattern = filePattern;
         this.encoding = encoding;
@@ -32,16 +30,17 @@ public class SloccountParser implements FilePath.FileCallable<SloccountReport> {
 
 
     public SloccountReport invoke(java.io.File workspace, VirtualChannel channel) throws IOException {
+        SloccountReport report = new SloccountReport();
         
         FileFinder finder = new FileFinder(this.filePattern);
         String[] found = finder.find(workspace);
 
         for(String fileName : found){
-            this.parse(workspace, fileName, this.report);
+            this.parse(workspace, fileName, report);
         }
 
-        this.report.simplifyNames();
-        return this.report;
+        report.simplifyNames();
+        return report;
     }
 
     private void parse(java.io.File workspace, String fileName, SloccountReport report) throws IOException {
@@ -86,7 +85,7 @@ public class SloccountParser implements FilePath.FileCallable<SloccountReport> {
         if(LOG_ENABLED && (this.logger != null)){
             logger.println("lineCount: " + lineCount);
             logger.println("language : " + languageName);
-            logger.println("file     : " + filePath);
+            logger.println("file : " + filePath);
         }
 
         report.add(filePath, languageName, lineCount);


### PR DESCRIPTION
I've revoked the last "optimization" in commit 2d0f2d6358cad6ae144abef5e6f304c4e3e5bb94 to keep the backward compatibility. The introducing of a new class field 'report' in class SloccountParser has lead to a change of the serialVersionUID and this leads to the java.io.InvalidClassException as reported in #JENKINS-14255.
