### PR TITLE
fixed german localization messages

### DIFF
--- a/src/main/resources/hudson/plugins/sloccount/Messages_de.properties
+++ b/src/main/resources/hudson/plugins/sloccount/Messages_de.properties
@@ -1,37 +1,5 @@
-Trend.PriorityHigh=(hohe Priorität)
-Trend.PriorityNormal=(normale Priorität)
-Trend.PriorityLow=(niedrige Priorität)
+Sloccount.Publisher.Name=Anzeige der SLOCCount Analyseergebnisse
 
-Priority.High=Hoch
-Priority.Normal=Normal
-Priority.Low=Niedrig
+Sloccount.ProjectAction.Name=SLOCCount
 
-Errors=Fehlermeldungen
-
-HighPriority=Hohe Priorität
-LowPriority=Niedrige Priorität
-NormalPriority=Normale Priorität
-
-ModuleDetail.header=Projekt
-PackageDetail.header=Package
-NamespaceDetail.header=Namespace
-CategoryDetail.header=Kategorie
-TypeDetail.header=Typ
-
-FixedWarningsDetail.Name=Behobene Warnungen
-NewWarningsDetail.Name=Neue Warnungen
-
-Reporter.Error.NoEncoding=Im pom.xml wurde keine Dateikodierung festgelegt, daher wird die vorgegebene Kodierung {0} des aktuellen Systems verwendet. Damit wird der Build abhängig vom System, auf dem er läuft (siehe auch <a href=\"http://docs.codehaus.org/display/MAVENUSER/POM+Element+for+Source+File+Encoding\">Maven FAQ</a>).
-
-Result.Error.ModuleErrorMessage=Projekt {0}: {1}
-
-FilesParser.Error.NoFiles=Keine Reportdateien gefunden. Bitte die Konfiguration überprüfen.
-FilesParser.Error.NoPermission=Überspringe Datei {0}, da keine Leseberechtigung besteht.
-FilesParser.Error.EmptyFile=Überspringe Datei {0}, da sie leer ist.
-FilesParser.Error.Exception=Das Einlesen der Datei {0} ist wegen folgender Exception fehgeschlagen:
-
-FieldValidator.Error.Threshold=Der Grenzwert muss eine ganze Zahl größer oder gleich 0 sein.
-FieldValidator.Error.DefaultEncoding=Die Zeichenkodierung muss von der Java Plattform unterstützt sein (siehe auch java.nio.charset.Charset).
-FieldValidator.Error.TrendHeight=Die Höhe des Trendreports muss eine ganze Zahl größer oder gleich {0} sein.
-
-
+Sloccount.Trend.Name=SLOCCount Trend

--- a/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config_de.properties
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config_de.properties
@@ -1,6 +1,10 @@
-FindBugs\ results=Dateiname FindBugs Ergebnisse
+SLOCCount\ reports=SLOCCount Ergebnisse
+Report\ charset=Bericht Zeichensatz
 description.pattern=Angabe einer <a href="{0}">ANT Fileset 'includes'</a> \
-             		Anweisung, die den Pfad zu den erzeugten FindBugs XML Dateien bestimmt, z.B. '**/findbugs.xml'. \
+             		Anweisung, die den Pfad zu den erzeugten SLOCCount Berichtdateien bestimmt, z.B. '**/sloccount.sc'. \
              		Als Ausgangsverzeichnis für diese Anweisung wird der <a href="ws/">Arbeitsbereich</a> verwendet. \
-             		Falls kein Wert eingetragen wird, dann wird die Vorgabe '**/findbugs.xml' benutzt. Bitte darauf \
-             		achten, dass damit keine anderen Dateien ausgewählt werden, sonst schlägt das Einlesen fehl.
+             		Falls kein Wert eingetragen wird, dann wird die Vorgabe '**/sloccount.sc' benutzt. Bitte darauf \
+             		achten, dass damit keine anderen Dateien ausgewählt werden, sonst schlägt das Einlesen fehl.\
+             		Der Bericht muss mit den sloccount Optionen "--wide --details" erzeugt worden sein.
+description.encoding=Zeichensatz welcher beim Einlesen der SLOCCount Berichtdateien verwendet wird. \
+             		Ist kein Wert angegeben wird als Standard 'UTF-8' verwendet.


### PR DESCRIPTION
Seems that the german messages were copy/pasted from a findbug plugin. I just translate it right.
