### PR TITLE
Made the plugin applicable for Job Generator jobs.

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/SloccountDescriptor.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountDescriptor.java
@@ -1,9 +1,11 @@
 package hudson.plugins.sloccount;
 
+
 import hudson.Extension;
 import hudson.maven.AbstractMavenProject;
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleProject;
+import hudson.model.Hudson;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 
@@ -19,7 +21,9 @@ public class SloccountDescriptor extends BuildStepDescriptor<Publisher> {
     }
 
     public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-        return AbstractMavenProject.class.isAssignableFrom(jobType) || FreeStyleProject.class.isAssignableFrom(jobType);
+        return AbstractMavenProject.class.isAssignableFrom(jobType) ||
+               FreeStyleProject.class.isAssignableFrom(jobType) ||
+               jobType.getSimpleName().equals("JobGenerator");
     }
 
     @Override


### PR DESCRIPTION
Hello,

I'm the author of the Job Generator Plugin (https://wiki.jenkins-ci.org/display/JENKINS/Job+Generator+Plugin).
Could you consider to merge this quick fix aimed to make the sloccount plugin available in Job Generators configuration ?

Thank you!

Cheers,
syl20bnr
