### PR TITLE
Remove needless call of super() function within the SloccountChartBuilder constructor.

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/SloccountChartBuilder.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountChartBuilder.java
@@ -25,7 +25,6 @@ import org.jfree.ui.RectangleInsets;
 public class SloccountChartBuilder implements Serializable {
 
     private SloccountChartBuilder(){
-        super();
     }
 
     public static JFreeChart buildChart(SloccountBuildAction action){


### PR DESCRIPTION
...tend a base class. Therefore, a call of the super() function is needless. This function call has been removed from the SloccountChartBuilder constructor.
