### PR TITLE
Section distributionManagement removed from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,15 +76,4 @@
     <url>https://github.com/jenkinsci/sloccount-plugin</url>
   </scm>
 
-  <distributionManagement>
-    <repository>
-      <id>java.net-m2-repository</id>
-      <url>http://maven.jenkins-ci.org/content/repositories/releases/</url>
-    </repository>
-    <site>
-      <id>github-project-site</id>
-      <url>gitsite:git@github.com/jenkinsci/sloccount-plugin</url>
-    </site>
-  </distributionManagement>
-
 </project>


### PR DESCRIPTION
- The section mentions legacy java.net-m2-repository, new maven.jenkins-ci.org should be used instead.
- Other plugins doesn't contain the section at all (e.g. Warnings, Android Lint), so the remove should be safe.
- https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins
