### PR TITLE
[JENKINS-21557] Possibly too wide table on summary page

### DIFF
--- a/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/summary.jelly
@@ -11,6 +11,7 @@
         <j:set var="diff" value="${it.diffSummary}"/>
         
         <style type="text/css">
+        #sloccountSummary { width: auto; }
         #sloccountSummary .number { text-align: right; }
         </style>
 


### PR DESCRIPTION
- Width of table on summary page depends on other areas of the page. If there is e.g. long message in a commit log, the table will be very wide.
- It seems the default table width is set to 100% in CSS, change to "auto" helps.
- Tested in Chrome, Firefox and Opera.
