### PR TITLE
[JENKINS-21700] Sorting using Distribution column/graph doesn't work

### DIFF
--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/files.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/files.jelly
@@ -21,7 +21,7 @@
           <td class="pane">${container.language}</td>
           <td class="pane">${container.part}</td>
           <td class="pane number" data="${container.lineCount}">${container.lineCountString}</td>
-          <td class="pane"><st:include page="/tabview/distribution-graph.jelly" /></td>
+          <td class="pane" data="${container.lineCount}"><st:include page="/tabview/distribution-graph.jelly" /></td>
         </tr>
       </j:forEach>
     </tbody>
@@ -31,7 +31,7 @@
         <td class="pane-header"> </td>
         <td class="pane-header"> </td>
         <td class="pane-header number" data="${cachedReport.lineCount}">${cachedReport.lineCountString}</td>
-        <td class="pane-header"> </td>
+        <td class="pane-header" data="0"> </td>
       </tr>
     </tfoot>
   </table>

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/folders.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/folders.jelly
@@ -19,7 +19,7 @@
           <td class="pane"><a href="folderResult/${container.urlName}">${container.name}</a></td>
           <td class="pane number" data="${container.fileCount}">${container.fileCountString}</td>
           <td class="pane number" data="${container.lineCount}">${container.lineCountString}</td>
-          <td class="pane"><st:include page="/tabview/distribution-graph.jelly" /></td>
+          <td class="pane" data="${container.lineCount}"><st:include page="/tabview/distribution-graph.jelly" /></td>
         </tr>
       </j:forEach>
     </tbody>
@@ -28,7 +28,7 @@
         <td class="pane-header">${%Total} ${cachedReport.folderCountString}</td>
         <td class="pane-header number" data="${cachedReport.fileCount}">${cachedReport.fileCountString}</td>
         <td class="pane-header number" data="${cachedReport.lineCount}">${cachedReport.lineCountString}</td>
-        <td class="pane-header"> </td>
+        <td class="pane-header" data="0"> </td>
       </tr>
     </tfoot>
   </table>

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/languages.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/languages.jelly
@@ -19,7 +19,7 @@
           <td class="pane"><a href="languageResult/${container.name}">${container.name}</a></td>
           <td class="pane number" data="${container.fileCount}">${container.fileCountString}</td>
           <td class="pane number" data="${container.lineCount}">${container.lineCountString}</td>
-          <td class="pane"><st:include page="/tabview/distribution-graph.jelly" /></td>
+          <td class="pane" data="${container.lineCount}"><st:include page="/tabview/distribution-graph.jelly" /></td>
         </tr>
       </j:forEach>
     </tbody>
@@ -28,7 +28,7 @@
         <td class="pane-header">${%Total} ${cachedReport.languageCountString}</td>
         <td class="pane-header number" data="${cachedReport.fileCount}">${cachedReport.fileCountString}</td>
         <td class="pane-header number" data="${cachedReport.lineCount}">${cachedReport.lineCountString}</td>
-        <td class="pane-header"> </td>
+        <td class="pane-header" data="0"> </td>
       </tr>
     </tfoot>
   </table>

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/parts.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/parts.jelly
@@ -19,7 +19,7 @@
           <td class="pane"><a href="partResult/${container.name}">${container.name}</a></td>
           <td class="pane number" data="${container.fileCount}">${container.fileCountString}</td>
           <td class="pane number" data="${container.lineCount}">${container.lineCountString}</td>
-          <td class="pane"><st:include page="/tabview/distribution-graph.jelly" /></td>
+          <td class="pane" data="${container.lineCount}"><st:include page="/tabview/distribution-graph.jelly" /></td>
         </tr>
       </j:forEach>
     </tbody>
@@ -28,7 +28,7 @@
         <td class="pane-header">${%Total} ${cachedReport.partCountString}</td>
         <td class="pane-header number" data="${cachedReport.fileCount}">${cachedReport.fileCountString}</td>
         <td class="pane-header number" data="${cachedReport.lineCount}">${cachedReport.lineCountString}</td>
-        <td class="pane-header"> </td>
+        <td class="pane-header" data="0"> </td>
       </tr>
     </tfoot>
   </table>


### PR DESCRIPTION
- If table header Distribution on report page is clicked, the rows will be sorted randomly.
- The rows are now sorted according to the lines count.
- data="0" in tfoot row is needed for proper sorting (unknown why).
