### PR TITLE
[JENKINS-22160] Fix findings from FindBugs static analysis

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/SloccountResult.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountResult.java
@@ -64,7 +64,7 @@ public class SloccountResult implements Serializable {
      * 
      * @return this with optionally updated data
      */
-    private Object readResolve() {
+    protected Object readResolve() {
         if (report != null && statistics == null) {
             List<SloccountLanguageStatistics> languages = new ArrayList<SloccountLanguageStatistics>();
 


### PR DESCRIPTION
- Private readResolve method in hudson.plugins.sloccount.SloccountResult not inherited by subclasses.
