### PR TITLE
[JENKINS-22303] Should have option to not care about build failure status

### DIFF
--- a/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config.jelly
@@ -12,5 +12,10 @@
         <f:entry title="${%Builds in graph}" description="${%description.numBuildsInGraph}">
             <f:textbox name="numBuildsInGraph" value="${instance.numBuildsInGraph}"/>
         </f:entry>
+
+        <f:entry>
+            <f:checkbox name="ignoreBuildFailure" checked="${instance.ignoreBuildFailure}"/>
+            <label for="ignoreBuildFailure">${%Try to process the report files even if the build is not successful}</label>
+        </f:entry>
     </f:advanced>
 </j:jelly>


### PR DESCRIPTION
- Option to try to process the report files even if the build is not successful added to job configuration.
- If no file is matching the input pattern, no data are stored and the build is marked as failed.
