### PR TITLE
[JENKINS-22303] Should have option to not care about build failure statu...

### DIFF
--- a/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config.jelly
@@ -15,7 +15,7 @@
 
         <f:entry>
             <f:checkbox name="ignoreBuildFailure" checked="${instance.ignoreBuildFailure}"/>
-            <label for="ignoreBuildFailure">${%Try to process the report files even if the build is not successful}</label>
+            <label class="attach-previous">${%Try to process the report files even if the build is not successful}</label>
         </f:entry>
     </f:advanced>
 </j:jelly>


### PR DESCRIPTION
...s
- Regression found by injected unit test fixed.
- <label for=...> shouldn't be used because it doesn't work when the configuration item is repeated. Use <label class="attach-previous"> to have your label attach to the previous DOM node instead.
