### PR TITLE
[JENKINS-22597] Error 404 when trying to access language details for "C/...

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/SloccountDiffLanguage.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountDiffLanguage.java
@@ -1,5 +1,7 @@
 package hudson.plugins.sloccount;
 
+import hudson.plugins.sloccount.util.HtmlUtil;
+
 /**
  * Storage for differences of a language between two reports.
  * 
@@ -33,5 +35,9 @@ public class SloccountDiffLanguage extends SloccountDiff {
 
     public String getName() {
         return name;
+    }
+
+    public String getUrlName() {
+    	return HtmlUtil.urlEncode(name);
     }
 }

--- a/src/main/java/hudson/plugins/sloccount/SloccountResult.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountResult.java
@@ -142,8 +142,7 @@ public class SloccountResult implements Serializable {
         return new BreadCrumbResult(filtered, owner, module);
     }
 
-    public SloccountResult getFolderResult(String jumbledFolder){
-        String folder = jumbledFolder.replace("|", SloccountReport.DIRECTORY_SEPARATOR);
+    public SloccountResult getFolderResult(String folder){
         SloccountReport filtered = new SloccountReport(this.getReport(), new FolderFileFilter(folder));
         return new BreadCrumbResult(filtered, this.owner, folder);
     }

--- a/src/main/java/hudson/plugins/sloccount/model/Folder.java
+++ b/src/main/java/hudson/plugins/sloccount/model/Folder.java
@@ -1,5 +1,7 @@
 package hudson.plugins.sloccount.model;
 
+import hudson.plugins.sloccount.util.HtmlUtil;
+
 /**
  *
  * @author lordofthepigs
@@ -23,6 +25,6 @@ public class Folder extends FileContainer {
     }
 
     public String getUrlName(){
-        return this.name.replace(SloccountReport.DIRECTORY_SEPARATOR, "|");
+        return HtmlUtil.urlEncode(name);
     }
 }

--- a/src/main/java/hudson/plugins/sloccount/model/Language.java
+++ b/src/main/java/hudson/plugins/sloccount/model/Language.java
@@ -1,5 +1,7 @@
 package hudson.plugins.sloccount.model;
 
+import hudson.plugins.sloccount.util.HtmlUtil;
+
 /**
  *
  * @author lordofthepigs
@@ -16,5 +18,9 @@ public class Language extends FileContainer {
 
     public String getName() {
         return this.name;
+    }
+
+    public String getUrlName() {
+        return HtmlUtil.urlEncode(name);
     }
 }

--- a/src/main/java/hudson/plugins/sloccount/model/Module.java
+++ b/src/main/java/hudson/plugins/sloccount/model/Module.java
@@ -1,6 +1,8 @@
 
 package hudson.plugins.sloccount.model;
 
+import hudson.plugins.sloccount.util.HtmlUtil;
+
 /**
  * Module name is present in the third column of SLOCCount utility output.
  * Modules are often the top level directories. 
@@ -25,5 +27,9 @@ public class Module extends FileContainer {
 
     public String getName() {
         return this.name;
+    }
+
+    public String getUrlName(){
+        return HtmlUtil.urlEncode(name);
     }
 }

--- a/src/main/java/hudson/plugins/sloccount/util/HtmlUtil.java
+++ b/src/main/java/hudson/plugins/sloccount/util/HtmlUtil.java
@@ -1,0 +1,30 @@
+package hudson.plugins.sloccount.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+/**
+ * HTML related utilities.
+ * 
+ * @author Michal Turek
+ */
+public class HtmlUtil {
+    /**
+     * Encode string so it can be used as URL.
+     * 
+     * @param url
+     *            the input string
+     * @return the string encoded as URL or the input string on error.
+     * @see URLEncoder#encode(String, String)
+     */
+    public static String urlEncode(String url) {
+        try {
+            // "%20" instead of "+" to be compatible with decoder inside Jenkins
+            // "C/C++ Header" -> "C%2FC%2B%2B+Header" -> "C/C+++Header"
+            return URLEncoder.encode(url, "UTF-8").replace("+", "%20");
+        } catch (UnsupportedEncodingException e) {
+            // Should never happen, UTF-8 should be always defined
+            return url;
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/summary.jelly
@@ -28,7 +28,7 @@
             <tbody>
                 <j:forEach var="language" items="${diff.languageDiffs}">
                 <tr>
-                    <td class="pane"><a href="sloccountResult/languageResult/${language.name}">${language.name}</a></td>
+                    <td class="pane"><a href="sloccountResult/languageResult/${language.urlName}">${language.name}</a></td>
                     <td class="pane number" data="${language.lineCount}">${language.lineCountString}</td>
                     <td class="pane number" data="${language.lineCountDelta}">${language.lineCountDeltaString}</td>
                     <td class="pane number" data="${language.fileCount}">${language.fileCountString}</td>

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/languages.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/languages.jelly
@@ -16,7 +16,7 @@
       <j:set var="max" value="${cachedReport.longestLanguage.lineCount}"/>
       <j:forEach var="container" items="${cachedReport.languages}">
         <tr>
-          <td class="pane"><a href="languageResult/${container.name}">${container.name}</a></td>
+          <td class="pane"><a href="languageResult/${container.urlName}">${container.name}</a></td>
           <td class="pane number" data="${container.fileCount}">${container.fileCountString}</td>
           <td class="pane number" data="${container.lineCount}">${container.lineCountString}</td>
           <td class="pane" data="${container.lineCount}"><st:include page="/tabview/distribution-graph.jelly" /></td>

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/modules.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/modules.jelly
@@ -16,7 +16,7 @@
       <j:set var="max" value="${cachedReport.longestModule.lineCount}"/>
       <j:forEach var="container" items="${cachedReport.modules}">
         <tr>
-          <td class="pane"><a href="moduleResult/${container.name}">${container.name}</a></td>
+          <td class="pane"><a href="moduleResult/${container.urlName}">${container.name}</a></td>
           <td class="pane number" data="${container.fileCount}">${container.fileCountString}</td>
           <td class="pane number" data="${container.lineCount}">${container.lineCountString}</td>
           <td class="pane" data="${container.lineCount}"><st:include page="/tabview/distribution-graph.jelly" /></td>


### PR DESCRIPTION
...C++ Header"
- Helper method HtmlUtil.urlEncode() defined.
- getUrlName() method added to Folder, Language and Module classes and used for all URLs in HTML links.
- URL decoding is done out of the box in SloccountResult.get*Result() methods.
