### PR TITLE
[JENKINS-35234] Support the new workflow/pipeline model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.447</version>
+    <version>2.7</version>
   </parent>
 
   <groupId>hudson.plugins.sloccount</groupId>
@@ -55,10 +55,48 @@
 
   <dependencies>
     <dependency>
+     <groupId>org.jenkins-ci.main</groupId>
+     <artifactId>jenkins-core</artifactId>
+     <version>2.63</version>
+     <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>dashboard-view</artifactId>
       <version>2.0</version>
       <optional>true</optional>
+    </dependency>
+    <!-- dependencies on Jenkins Pipeline plugins -->  
+    <dependency>  
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
+      <artifactId>workflow-job</artifactId>  
+      <version>1.14</version>  
+    </dependency>  
+    <dependency>  
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
+      <artifactId>workflow-cps</artifactId>  
+      <version>2.34</version>  
+    </dependency>  
+    <dependency>  
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
+      <artifactId>workflow-support</artifactId>  
+      <version>2.14</version>  
+    </dependency>  
+    <dependency>  
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
+      <artifactId>workflow-durable-task-step</artifactId>  
+      <version>2.11</version>  
+    </dependency> 
+    <dependency>  
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
+      <artifactId>workflow-step-api</artifactId>  
+      <version>2.11</version>  
+    </dependency>
+    <dependency>  
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>  
+        <artifactId>workflow-basic-steps</artifactId>  
+        <version>2.0</version>  
+        <scope>test</scope>  
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.7</version>
+    <version>2.30</version>
   </parent>
 
   <groupId>hudson.plugins.sloccount</groupId>
@@ -51,22 +51,21 @@
 
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <jenkins.version>1.625.3</jenkins.version>
   </properties>
 
   <dependencies>
-    <dependency>
-     <groupId>org.jenkins-ci.main</groupId>
-     <artifactId>jenkins-core</artifactId>
-     <version>2.63</version>
-     <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>dashboard-view</artifactId>
       <version>2.0</version>
       <optional>true</optional>
     </dependency>
-    <!-- dependencies on Jenkins Pipeline plugins -->  
+    <dependency>  
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
+      <artifactId>workflow-step-api</artifactId>  
+      <version>2.6</version>  
+    </dependency>
     <dependency>  
       <groupId>org.jenkins-ci.plugins.workflow</groupId>  
       <artifactId>workflow-job</artifactId>  
@@ -75,22 +74,15 @@
     <dependency>  
       <groupId>org.jenkins-ci.plugins.workflow</groupId>  
       <artifactId>workflow-cps</artifactId>  
-      <version>2.34</version>  
+      <version>1.14</version>  
     </dependency>  
+
+    <!-- dependencies on Jenkins Pipeline plugins for tests-->  
     <dependency>  
       <groupId>org.jenkins-ci.plugins.workflow</groupId>  
       <artifactId>workflow-support</artifactId>  
-      <version>2.14</version>  
-    </dependency>  
-    <dependency>  
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
-      <artifactId>workflow-durable-task-step</artifactId>  
-      <version>2.11</version>  
-    </dependency> 
-    <dependency>  
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>  
-      <artifactId>workflow-step-api</artifactId>  
-      <version>2.11</version>  
+      <version>1.14</version>
+      <scope>test</scope>  
     </dependency>
     <dependency>  
         <groupId>org.jenkins-ci.plugins.workflow</groupId>  

--- a/src/main/java/hudson/plugins/sloccount/SloccountAreaRenderer.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountAreaRenderer.java
@@ -1,5 +1,6 @@
 package hudson.plugins.sloccount;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.util.StackedAreaRenderer2;
 import hudson.util.ChartUtil.NumberOnlyBuildLabel;
 
@@ -10,6 +11,7 @@ import org.jfree.data.category.CategoryDataset;
  * links. This renderer does not render tooltips, these need to be defined in
  * sub-classes.
  */
+@SuppressFBWarnings(value="EQ_DOESNT_OVERRIDE_EQUALS", justification="Equals method is not needed.")
 public class SloccountAreaRenderer extends StackedAreaRenderer2 {
     /** Unique identifier of this class. */
     private static final long serialVersionUID = 1440842055316682192L;
@@ -30,7 +32,7 @@ public class SloccountAreaRenderer extends StackedAreaRenderer2 {
     /** {@inheritDoc} */
     @Override
     public final String generateURL(final CategoryDataset dataset, final int row, final int column) {
-        return getLabel(dataset, column).build.getNumber() + url;
+        return getLabel(dataset, column).getRun().getNumber() + url;
     }
 
     /**

--- a/src/main/java/hudson/plugins/sloccount/SloccountBuildAction.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountBuildAction.java
@@ -132,6 +132,8 @@ public class SloccountBuildAction implements RunAction2, StaplerProxy, SimpleBui
             this.projectActions = new ArrayList<>();  
         }
         this.projectActions.add(new SloccountProjectAction(this.build.getParent(), this.numBuildsInGraph));  
+        
+        this.result.setOwner(r);
     }
     
     @Override

--- a/src/main/java/hudson/plugins/sloccount/SloccountProjectAction.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountProjectAction.java
@@ -1,11 +1,10 @@
 package hudson.plugins.sloccount;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.Job;
 import hudson.model.Action;
 import hudson.util.ChartUtil;
 import java.io.IOException;
-import java.io.Serializable;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -13,16 +12,14 @@ import org.kohsuke.stapler.StaplerResponse;
  *
  * @author lordofthepigs
  */
-public class SloccountProjectAction implements Action, Serializable {
-    /** Serial version UID. */
-    private static final long serialVersionUID = 0L;
+public class SloccountProjectAction implements Action {
 
     public static final String URL_NAME = "sloccountResult";
 
     public static final int CHART_WIDTH = 500;
     public static final int CHART_HEIGHT = 200;
 
-    public AbstractProject<?,?> project;
+    public transient Job<?,?> project;
 
     /** 
      * Maximal number of last successful builds displayed in the trend graphs.
@@ -30,7 +27,7 @@ public class SloccountProjectAction implements Action, Serializable {
      */
     private final int numBuildsInGraph;
 
-    public SloccountProjectAction(final AbstractProject<?, ?> project,
+    public SloccountProjectAction(final Job<?, ?> project,
             int numBuildsInGraph) {
         this.project = project;
         this.numBuildsInGraph = numBuildsInGraph;
@@ -60,7 +57,7 @@ public class SloccountProjectAction implements Action, Serializable {
      *             in case of an error
      */
     public void doIndex(final StaplerRequest request, final StaplerResponse response) throws IOException {
-        AbstractBuild<?, ?> build = getLastFinishedBuild();
+        Run<?, ?> build = getLastFinishedBuild();
         if (build != null) {
             response.sendRedirect2(String.format("../%d/%s", build.getNumber(), SloccountBuildAction.URL_NAME));
         }else{
@@ -75,8 +72,8 @@ public class SloccountProjectAction implements Action, Serializable {
      * @return the last finished build or <code>null</code> if there is no
      *         such build
      */
-    public AbstractBuild<?, ?> getLastFinishedBuild() {
-        AbstractBuild<?, ?> lastBuild = project.getLastBuild();
+    public Run<?, ?> getLastFinishedBuild() {
+        Run<?, ?> lastBuild = project.getLastBuild();
         while (lastBuild != null && (lastBuild.isBuilding() || lastBuild.getAction(SloccountBuildAction.class) == null)) {
             lastBuild = lastBuild.getPreviousBuild();
         }
@@ -89,12 +86,12 @@ public class SloccountProjectAction implements Action, Serializable {
      * @return the build action or null
      */
     public SloccountBuildAction getLastFinishedBuildAction() {
-        AbstractBuild<?, ?> lastBuild = getLastFinishedBuild();
+        Run<?, ?> lastBuild = getLastFinishedBuild();
         return (lastBuild != null) ? lastBuild.getAction(SloccountBuildAction.class) : null;
     }
 
     public final boolean hasValidResults() {
-        AbstractBuild<?, ?> build = getLastFinishedBuild();
+        Run<?, ?> build = getLastFinishedBuild();
 
         if (build != null) {
             SloccountBuildAction resultAction = build.getAction(SloccountBuildAction.class);
@@ -130,8 +127,7 @@ public class SloccountProjectAction implements Action, Serializable {
      *             in case of an error
      */
     public void doTrendMap(final StaplerRequest request, final StaplerResponse response) throws IOException {
-        AbstractBuild<?,?> lastBuild = this.getLastFinishedBuild();
-        SloccountBuildAction lastAction = lastBuild.getAction(SloccountBuildAction.class);
+        SloccountBuildAction lastAction = getLastFinishedBuildAction();
 
         ChartUtil.generateClickableMap(
                 request,
@@ -152,8 +148,7 @@ public class SloccountProjectAction implements Action, Serializable {
      *             in case of an error
      */
     public void doTrend(final StaplerRequest request, final StaplerResponse response) throws IOException {
-        AbstractBuild<?,?> lastBuild = this.getLastFinishedBuild();
-        SloccountBuildAction lastAction = lastBuild.getAction(SloccountBuildAction.class);
+        SloccountBuildAction lastAction = getLastFinishedBuildAction();
 
         ChartUtil.generateGraph(
                 request,
@@ -174,8 +169,7 @@ public class SloccountProjectAction implements Action, Serializable {
      *             in case of an error
      */
     public void doTrendDeltaMap(final StaplerRequest request, final StaplerResponse response) throws IOException {
-        AbstractBuild<?,?> lastBuild = this.getLastFinishedBuild();
-        SloccountBuildAction lastAction = lastBuild.getAction(SloccountBuildAction.class);
+        SloccountBuildAction lastAction = getLastFinishedBuildAction();
 
         ChartUtil.generateClickableMap(
                 request,
@@ -196,8 +190,7 @@ public class SloccountProjectAction implements Action, Serializable {
      *             in case of an error
      */
     public void doTrendDelta(final StaplerRequest request, final StaplerResponse response) throws IOException {
-        AbstractBuild<?,?> lastBuild = this.getLastFinishedBuild();
-        SloccountBuildAction lastAction = lastBuild.getAction(SloccountBuildAction.class);
+        SloccountBuildAction lastAction = getLastFinishedBuildAction();
 
         ChartUtil.generateGraph(
                 request,

--- a/src/main/java/hudson/plugins/sloccount/SloccountPublisher.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountPublisher.java
@@ -2,10 +2,8 @@ package hudson.plugins.sloccount;
 
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.model.Result;
 import hudson.plugins.sloccount.model.SloccountPublisherReport;
 import hudson.plugins.sloccount.model.SloccountParser;
@@ -13,6 +11,7 @@ import hudson.plugins.sloccount.model.SloccountPublisherReport.SlaveFile;
 import hudson.remoting.VirtualChannel;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Recorder;
+import jenkins.tasks.SimpleBuildStep;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -20,6 +19,7 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.List;
 import java.io.File;
+import javax.annotation.Nonnull;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -27,7 +27,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  *
  * @author lordofthepigs
  */
-public class SloccountPublisher extends Recorder implements Serializable {
+public class SloccountPublisher extends Recorder implements SimpleBuildStep, Serializable {
     /** Serial version UID. */
     private static final long serialVersionUID = 0L;
 
@@ -61,17 +61,12 @@ public class SloccountPublisher extends Recorder implements Serializable {
         this.ignoreBuildFailure = ignoreBuildFailure;
     }
 
-    @Override
-    public Action getProjectAction(AbstractProject<?,?> project){
-        return new SloccountProjectAction(project, numBuildsInGraph);
-    }
-
     protected boolean canContinue(final Result result) {
         return result != Result.ABORTED && result != Result.FAILURE;
     }
 
     @Override
-    public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener){
+    public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) {
         PrintStream logger = listener.getLogger();
 
         if (!canContinue(build.getResult())) {
@@ -80,7 +75,7 @@ public class SloccountPublisher extends Recorder implements Serializable {
                 // Continue as usual
             } else {
                 logger.println("[SLOCCount] Skipping results publication since the build is not successful");
-                return true;
+                return;
             }
         }
 
@@ -89,38 +84,37 @@ public class SloccountPublisher extends Recorder implements Serializable {
         SloccountPublisherReport report;
 
         try{
-            report = build.getWorkspace().act(parser);
+            report = workspace.act(parser);
         }catch(IOException ioe){
             ioe.printStackTrace(logger);
-            return false;
+            return;
         }catch(InterruptedException ie){
             ie.printStackTrace(logger);
-            return false;
+            return;
         }
 
         if (report.getSourceFiles().size() == 0) {
             logger.format("[SLOCCount] No file is matching the input pattern: %s%n",
                     getRealPattern());
-            return false;
+            return;
         }
 
         SloccountResult result = new SloccountResult(report.getStatistics(),
                 getRealEncoding(), commentIsCode, null, build);
-        build.addAction(new SloccountBuildAction(build, result));
+        build.addAction(new SloccountBuildAction( result, this.numBuildsInGraph));
 
         try{
             copyFilesToBuildDirectory(report.getSourceFiles(),
                     build.getRootDir(), launcher.getChannel());
         }catch(IOException e){
             e.printStackTrace(logger);
-            return false;
+            return;
         }catch(InterruptedException e){
             e.printStackTrace(logger);
-            return false;
+            return;
         }
 
         logger.format("[SLOCCount] Report successfully processed and all data stored%n");
-        return true;
     }
 
     /**

--- a/src/main/java/hudson/plugins/sloccount/SloccountResult.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountResult.java
@@ -25,7 +25,7 @@ public class SloccountResult implements Serializable {
 
     private transient SloccountReport report;
 
-    private transient final Run<?,?> owner;
+    private transient Run<?,?> owner;
 
     /** The statistics. */
     private SloccountReportStatistics statistics;
@@ -51,6 +51,10 @@ public class SloccountResult implements Serializable {
 
     public Run<?,?> getOwner() {
         return owner;
+    }
+    
+    public void setOwner(Run<?,?> o) {
+        this.owner = o;
     }
 
     /**

--- a/src/main/java/hudson/plugins/sloccount/SloccountResult.java
+++ b/src/main/java/hudson/plugins/sloccount/SloccountResult.java
@@ -1,6 +1,6 @@
 package hudson.plugins.sloccount;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.Api;
 import hudson.model.ModelObject;
 import hudson.plugins.sloccount.model.File;
@@ -25,7 +25,7 @@ public class SloccountResult implements Serializable {
 
     private transient SloccountReport report;
 
-    private final AbstractBuild<?,?> owner;
+    private transient final Run<?,?> owner;
 
     /** The statistics. */
     private SloccountReportStatistics statistics;
@@ -37,7 +37,7 @@ public class SloccountResult implements Serializable {
 
     public SloccountResult(SloccountReportStatistics statistics, String encoding,
             boolean commentIsCode,
-            SloccountReport report, AbstractBuild<?,?> owner){
+            SloccountReport report, Run<?,?> owner){
         this.statistics = statistics;
         this.encoding = encoding;
         this.commentIsCode = commentIsCode;
@@ -49,7 +49,7 @@ public class SloccountResult implements Serializable {
         return lazyLoadReport();
     }
 
-    public AbstractBuild<?,?> getOwner() {
+    public Run<?,?> getOwner() {
         return owner;
     }
 
@@ -108,7 +108,15 @@ public class SloccountResult implements Serializable {
 
         SloccountParser parser = new SloccountParser(realEncoding, null, null,
                 commentIsCode);
-        return parser.parseFiles(destDir.listFiles());
+        java.io.File[] files = destDir.listFiles();
+        if( files != null)
+        {
+            return parser.parseFiles(files);
+        }
+        else
+        {
+            return null;
+        }
     }
 
     /**
@@ -224,7 +232,7 @@ public class SloccountResult implements Serializable {
 
         private String displayName = null;
         
-        public BreadCrumbResult(SloccountReport report, AbstractBuild<?,?> owner,
+        public BreadCrumbResult(SloccountReport report, Run<?,?> owner,
                                 String displayName, boolean commentIsCode){
             super(null, null, commentIsCode, report, owner);
             this.displayName = displayName;

--- a/src/main/java/hudson/plugins/sloccount/dashboard/SloccountTablePortlet.java
+++ b/src/main/java/hudson/plugins/sloccount/dashboard/SloccountTablePortlet.java
@@ -63,6 +63,7 @@ public class SloccountTablePortlet extends DashboardPortlet {
     /**
      * Format an integer to contain a thousands separator.
      * 
+     * @param value value to format
      * @return the formatted string
      */
     public String grouping(int value) {

--- a/src/main/java/hudson/plugins/sloccount/model/SloccountLanguageStatistics.java
+++ b/src/main/java/hudson/plugins/sloccount/model/SloccountLanguageStatistics.java
@@ -36,6 +36,7 @@ public class SloccountLanguageStatistics implements Serializable {
      *            number of lines in this language
      * @param fileCount
      *            number of files containing this language
+     * @param commentCount commentCount
      */
     public SloccountLanguageStatistics(String languageName, int lineCount,
             int fileCount, int commentCount){

--- a/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
+++ b/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
@@ -1,6 +1,6 @@
 package hudson.plugins.sloccount.model;
 
-import hudson.FilePath;
+import jenkins.MasterToSlaveFileCallable;
 import hudson.plugins.sloccount.model.cloc.ClocReport;
 import hudson.plugins.sloccount.util.FileFinder;
 import hudson.remoting.VirtualChannel;
@@ -17,8 +17,8 @@ import java.io.Reader;
  * 
  * @author lordofthepigs
  */
-public class SloccountParser implements
-        FilePath.FileCallable<SloccountPublisherReport> {
+public class SloccountParser extends
+        MasterToSlaveFileCallable<SloccountPublisherReport> {
     /** Serial version UID. */
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/hudson/plugins/sloccount/model/cloc/ClocFile.java
+++ b/src/main/java/hudson/plugins/sloccount/model/cloc/ClocFile.java
@@ -29,6 +29,12 @@ public class ClocFile implements Serializable {
 
     /**
      * Constructor.
+     * 
+     * @param name file name
+     * @param blank blank
+     * @param comment comment
+     * @param code code
+     * @param language language
      */
     public ClocFile(String name, int blank, int comment, int code, String language) {
         this.name = name;

--- a/src/main/java/hudson/plugins/sloccount/model/cloc/ClocFiles.java
+++ b/src/main/java/hudson/plugins/sloccount/model/cloc/ClocFiles.java
@@ -21,6 +21,8 @@ public class ClocFiles implements Serializable {
 
     /**
      * Constructor.
+     * @param files files
+     * @param total total
      */
     public ClocFiles(List<ClocFile> files, ClocTotal total) {
         this.files = files;

--- a/src/main/java/hudson/plugins/sloccount/model/cloc/ClocHeader.java
+++ b/src/main/java/hudson/plugins/sloccount/model/cloc/ClocHeader.java
@@ -38,6 +38,14 @@ public class ClocHeader implements Serializable {
 
     /**
      * Constructor.
+     * @param clocUrl URL of CLOC
+     * @param clocVersion version of CLOC
+     * @param elapsedSeconds time elapsed in seconds
+     * @param filesCount number of files
+     * @param linesCount number of lines
+     * @param filesPerSecond number of files per second
+     * @param linesPerSecond number of lines per second
+     * @param reportFile file with report
      */
     public ClocHeader(ClocParameter clocUrl, ClocParameter clocVersion,
                       ClocParameter elapsedSeconds, ClocParameter filesCount,

--- a/src/main/java/hudson/plugins/sloccount/model/cloc/ClocReport.java
+++ b/src/main/java/hudson/plugins/sloccount/model/cloc/ClocReport.java
@@ -31,6 +31,8 @@ public class ClocReport implements Serializable {
 
     /**
      * Constructor.
+     * @param header header
+     * @param files files
      */
     public ClocReport(ClocHeader header, ClocFiles files) {
         this.header = header;
@@ -70,7 +72,7 @@ public class ClocReport implements Serializable {
      *
      * @param report        output report
      * @param commentIsCode include comments to the measured lines
-     * @throws javax.xml.bind.JAXBContext if the report has unexpected structure
+     * @throws JAXBException if the report has unexpected structure
      */
     public void toSloccountReport(SloccountReportInterface report, boolean commentIsCode)
             throws JAXBException {

--- a/src/main/java/hudson/plugins/sloccount/model/cloc/ClocTotal.java
+++ b/src/main/java/hudson/plugins/sloccount/model/cloc/ClocTotal.java
@@ -23,6 +23,9 @@ public class ClocTotal implements Serializable {
 
     /**
      * Constructor.
+     * @param blank blank
+     * @param comment comment
+     * @param code code
      */
     public ClocTotal(int blank, int comment, int code) {
         this.blank = blank;

--- a/src/main/java/hudson/plugins/sloccount/util/FileFinder.java
+++ b/src/main/java/hudson/plugins/sloccount/util/FileFinder.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
+import org.jenkinsci.remoting.RoleChecker;
 
 /**
  * Scans the workspace and finds all Java files.
@@ -66,5 +67,10 @@ public class FileFinder implements FileCallable<String[]> {
         catch (BuildException exception) {
             return new String[0];
         }
+    }
+
+    @Override
+    public void checkRoles(RoleChecker rc) throws SecurityException {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/src/main/java/jenkins/plugins/sloccount/steps/SloccountPublisherStep.java
+++ b/src/main/java/jenkins/plugins/sloccount/steps/SloccountPublisherStep.java
@@ -1,0 +1,168 @@
+package jenkins.plugins.sloccount.steps;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import hudson.Extension; 
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.sloccount.SloccountPublisher;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor ; 
+import org.jenkinsci.plugins.workflow.steps.Step; 
+import org.kohsuke.stapler.DataBoundConstructor; 
+import org.kohsuke.stapler.DataBoundSetter;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+import java.util.Set;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+
+/**
+ *
+ * @author piomis
+ */
+public class SloccountPublisherStep extends Step implements Serializable {
+    /** 
+     * Archiving SLOC Count report
+     */
+    private String pattern = "";
+    private String encoding = "";
+    private boolean commentIsCode = true;
+    /** 
+     * Maximal number of last successful builds displayed in the trend graphs.
+     * One or less means unlimited.
+     */
+    private int numBuildsInGraph = 100;
+
+    /** Try to process the report files even if the build state is marked as failed. */
+    private boolean ignoreBuildFailure = false;
+    
+    @DataBoundConstructor
+    public SloccountPublisherStep(String pattern, String encoding,
+            boolean commentIsCode, int numBuildsInGraph,
+            boolean ignoreBuildFailure) {
+        this.pattern = pattern;
+        this.encoding = encoding;
+        this.commentIsCode = commentIsCode;
+        this.numBuildsInGraph = numBuildsInGraph;
+        this.ignoreBuildFailure = ignoreBuildFailure;
+    }
+    
+    public String getPattern() { 
+        return pattern; 
+    } 
+    @DataBoundSetter  
+    public void setPattern(String pattern) { 
+        this.pattern = pattern==null? null:pattern; 
+    }
+
+    public String getEncoding() { 
+        return encoding; 
+    } 
+    @DataBoundSetter  
+    public void setEncoding(String encoding) { 
+        this.encoding = encoding==null? null:encoding; 
+    }
+
+    public boolean getCommentIsCode() { 
+        return commentIsCode; 
+    } 
+    @DataBoundSetter  
+    public void setCommentIsCode(boolean commentIsCode) { 
+        this.commentIsCode = commentIsCode; 
+    }
+ 
+    public int getNumBuildsInGraph() { 
+        return numBuildsInGraph; 
+    } 
+    @DataBoundSetter  
+    public void setNumBuildsInGraph(int numBuildsInGraph) { 
+        this.numBuildsInGraph = numBuildsInGraph; 
+    }
+    
+    public boolean getIgnoreBuildFailure() { 
+        return ignoreBuildFailure; 
+    } 
+    @DataBoundSetter  
+    public void setIgnoreBuildFailure(boolean ignoreBuildFailure) { 
+        this.ignoreBuildFailure = ignoreBuildFailure; 
+    }
+    
+    @Override
+    public StepExecution start(StepContext context) throws Exception { 
+       return new SloccountPublisherStepExecution(this, context); 
+    } 
+
+    @Extension 
+    public static final class DescriptorImpl extends StepDescriptor { 
+        /*public DescriptorImpl() { super(SloccountPublisherStepExecution.class); } */
+ 
+ 
+        @Override 
+        public String getFunctionName() { 
+            return "sloccountPublish"; 
+        } 
+
+        @Override 
+        public Set<? extends Class<?>> getRequiredContext() { 
+           return ImmutableSet.of(FilePath.class, Run.class, Launcher.class, TaskListener.class); 
+        } 
+
+ 
+        @Nonnull
+        @Override 
+        public String getDisplayName() { 
+            return "Publish Sloccount reports"; 
+        } 
+     } 
+    
+    private static final class SloccountPublisherStepExecution extends SynchronousNonBlockingStepExecution<Void> {
+
+        /** Serial version UID. */
+        private static final long serialVersionUID = 1L;
+        
+        @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
+        private transient final SloccountPublisherStep step;
+
+        @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
+        private transient final Run<?, ?> run; 
+        
+        @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
+        private transient final TaskListener listener; 
+        
+        @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
+        private transient final FilePath ws;
+        
+        @SuppressFBWarnings(value="SE_TRANSIENT_FIELD_NOT_RESTORED", justification="Only used when starting.")
+        private transient final Launcher launcher;
+
+
+        SloccountPublisherStepExecution(SloccountPublisherStep step, StepContext context) throws IOException, InterruptedException { 
+           super(context); 
+           this.step = step;
+           this.listener = context.get(TaskListener.class);
+           this.run = context.get(Run.class);
+           this.ws = context.get(FilePath.class);
+           this.launcher = context.get(Launcher.class);
+        } 
+
+
+        @Override  
+        protected Void run() throws Exception {  
+            listener.getLogger().println("Running Sloccount Publisher step");  
+
+            SloccountPublisher publisher = new SloccountPublisher(step.getPattern(),
+                    step.getEncoding(), step.getCommentIsCode(),
+                    step.getNumBuildsInGraph(), step.getIgnoreBuildFailure());  
+            publisher.perform(this.run, this.ws, this.launcher, this.listener);  
+            return null;  
+        }    
+    }
+}

--- a/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/statistics.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/statistics.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
     <style type="text/css">

--- a/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountBuildAction/summary.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
     <t:summary icon="/plugin/sloccount/icons/sloccount-48.png">
         <div><a href="${it.urlName}">${it.displayName}</a></div>

--- a/src/main/resources/hudson/plugins/sloccount/SloccountProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountProjectAction/floatingBox.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <j:if test="${from.hasValidResults()}">
         <div align="right">

--- a/src/main/resources/hudson/plugins/sloccount/SloccountProjectAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountProjectAction/jobMain.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:st="jelly:stapler">
     <table style="margin-left:1em;">
         <t:summary icon="/plugin/sloccount/icons/sloccount-48.png">

--- a/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%SLOCCount reports}" field="pattern">
         <f:textbox name="pattern" value="${instance.pattern}"/>

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/files.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/files.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:header name="Content-Type" value="text/html;charset=UTF-8" />
   <table class="pane sortable" id="files">

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/folders.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/folders.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:header name="Content-Type" value="text/html;charset=UTF-8" />
   <table class="pane sortable" id="files">

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/index.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <l:layout norefresh="true" title="${%SLOCCount Results}">
         <st:include it="${it.owner}" page="sidepanel.jelly" />

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/languages.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/languages.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:header name="Content-Type" value="text/html;charset=UTF-8" />
   <table class="pane sortable" id="files">

--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/modules.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/modules.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:header name="Content-Type" value="text/html;charset=UTF-8" />
   <table class="pane sortable" id="modules">

--- a/src/main/resources/hudson/plugins/sloccount/dashboard/SloccountTablePortlet/portlet.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/dashboard/SloccountTablePortlet/portlet.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
     xmlns:st="jelly:stapler"
     xmlns:dp="/hudson/plugins/view/dashboard">

--- a/src/main/resources/hudson/plugins/sloccount/dashboard/SloccountTablePortlet/table.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/dashboard/SloccountTablePortlet/table.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:dp="/hudson/plugins/view/dashboard">
 
     <style type="text/css">

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the plugin list page.
 -->

--- a/src/main/resources/jenkins/plugins/sloccount/steps/SloccountPublisherStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/sloccount/steps/SloccountPublisherStep/config.jelly
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>  
+<?jelly escape-by-default='true'?>  
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">  
+    <f:entry field="pattern" title="SLOCCount reports" description="Reports.">
+        <f:textbox/>
+    </f:entry>
+    
+    <f:advanced>
+        <f:entry field="encoding" title="Report charset" description="The character encoding of SLOCCount result files. If no value is set, default 'UTF-8' will be used. This option is considered only in the SLOCCount report parser and is ignored in the cloc one.">
+            <f:textbox/>
+        </f:entry>
+    
+        <f:entry field="numBuildsInGraph" title="Builds in graph" description="Maximal number of last successful builds, that are displayed in the trend graphs. Use 1 or less for unlimited.">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry field="commentIsCode" title="Comment is code" description="Blank lines and comments are not counted to code lines by default. But they often contain Javadoc or Doxygen documentation which is tightly connected to the code. This option is considered only in the cloc report parser and is ignored in the SLOCCount one.">
+            <f:checkbox/>
+        </f:entry>
+    
+        <f:entry field="ignoreBuildFailure" title="Ignore build failure" description="Try to process the report files even if the build is not successful.">
+            <f:checkbox/>
+        </f:entry>
+    </f:advanced>
+</j:jelly>

--- a/src/main/resources/tabview/css.jelly
+++ b/src/main/resources/tabview/css.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <style type="text/css">
 

--- a/src/main/resources/tabview/distribution-graph.jelly
+++ b/src/main/resources/tabview/distribution-graph.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
   <table cellpadding="0" cellspacing="0" width="100%">

--- a/src/main/resources/tabview/main.jelly
+++ b/src/main/resources/tabview/main.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
     <st:header name="Content-Type" value="text/html;charset=UTF-8" />
     <script type="text/javascript" src="${rootURL}/plugin/sloccount/yui/utilities.js"/>

--- a/src/test/java/jenkins/plugins/sloccount/steps/SloccountPublisherStepTest.java
+++ b/src/test/java/jenkins/plugins/sloccount/steps/SloccountPublisherStepTest.java
@@ -1,0 +1,99 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package jenkins.plugins.sloccount.steps;
+
+/**
+ *
+ * @author tzbjxk
+ */
+import org.apache.commons.lang.StringUtils; 
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition; 
+import org.jenkinsci.plugins.workflow.job.WorkflowJob; 
+import org.jenkinsci.plugins.workflow.job.WorkflowRun; 
+import org.junit.Assert; 
+import org.junit.Rule; 
+import org.junit.Test; 
+import org.jvnet.hudson.test.JenkinsRule; 
+import hudson.model.Action;  
+import hudson.plugins.sloccount.SloccountBuildAction;  
+
+import java.util.ArrayList;  
+import java.util.Arrays; 
+import java.util.List; 
+
+public class SloccountPublisherStepTest extends Assert { 
+   @Rule public JenkinsRule j = new JenkinsRule(); 
+
+    /** 
+     * Test archiving of sloccount reports 
+     */ 
+    @Test 
+    public void archive_1() throws Exception { 
+        // job setup 
+        WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo"); 
+        foo.setDefinition(new CpsFlowDefinition(StringUtils.join(Arrays.asList( 
+                "node {", 
+                "  writeFile file: 'sloc.xml', text: '<?xml version=\"1.0\" ?><results><files><file code=\"50\" comment=\"50\" language=\"C/C++\" name=\"file.h\"/><file code=\"300\" comment=\"100\" language=\"C/C++\" name=\"file.c\"/></files></results>'",
+                "  sloccountPublish ( ",
+                "     pattern: 'sloc.xml',",
+                "     encoding: '',",
+                "     commentIsCode: false,",
+                "     numBuildsInGraph: 1,",
+                "     ignoreBuildFailure: false )",
+                "}"), "\n"),false)); 
+ 
+        // get the build going, and wait until workflow pauses 
+        WorkflowRun b = j.assertBuildStatusSuccess(foo.scheduleBuild2(0).get()); 
+
+        List<SloccountBuildAction> sbas = new ArrayList<>();  
+        for (Action a : b.getAllActions()) {  
+            if (a instanceof SloccountBuildAction) {  
+                sbas.add((SloccountBuildAction) a);  
+            }  
+        }  
+        assertEquals("Should be exactly one SloccountBuildAction",  
+                1, sbas.size());  
+  
+        SloccountBuildAction buildAction = sbas.get(0);  
+        assertEquals("BuildAction should have exactly one ProjectAction",  
+                 1, buildAction.getProjectActions().size());  
+    } 
+    
+    /** 
+     * Test archiving of sloccount reports 
+     */ 
+    @Test 
+    public void archive_2() throws Exception { 
+        // job setup 
+        WorkflowJob foo = j.jenkins.createProject(WorkflowJob.class, "foo"); 
+        foo.setDefinition(new CpsFlowDefinition(StringUtils.join(Arrays.asList( 
+                "node {", 
+                "  writeFile file: 'sloc.xml', text: '<?xml version=\"1.0\" ?><results><files><file code=\"50\" comment=\"50\" language=\"C/C++\" name=\"file.h\"/><file code=\"300\" comment=\"100\" language=\"C/C++\" name=\"file.c\"/></files></results>'",
+                "  step([$class: 'SloccountPublisher',",
+                "     pattern: 'sloc.xml',",
+                "     encoding: '',",
+                "     commentIsCode: false,",
+                "     numBuildsInGraph: 1,",
+                "     ignoreBuildFailure: false])",
+                "}"), "\n"),false)); 
+ 
+        // get the build going, and wait until workflow pauses 
+        WorkflowRun b = j.assertBuildStatusSuccess(foo.scheduleBuild2(0).get()); 
+
+        List<SloccountBuildAction> sbas = new ArrayList<>();  
+        for (Action a : b.getAllActions()) {  
+            if (a instanceof SloccountBuildAction) {  
+                sbas.add((SloccountBuildAction) a);  
+            }  
+        }  
+        assertEquals("Should be exactly one SloccountBuildAction",  
+                1, sbas.size());  
+  
+        SloccountBuildAction buildAction = sbas.get(0);  
+        assertEquals("BuildAction should have exactly one ProjectAction",  
+                 1, buildAction.getProjectActions().size());  
+    } 
+} 


### PR DESCRIPTION
pom.xml
Added dependencies to workflow modules
Sloccount plugin now requires Jenkins 2.63

Refactored for new workflow (AbstractBuild and AbstractProject replaced
with Run<> and Job<>)
SloccountAreaRenderer.java
SloccountBuildAction.java
SloccountProjectAction.java
SloccountPublisher.java
SloccountResult.java

Solved NPE:
SloccountResult.java

Ignored FindBug errors:
SloccountAreaRenderer.java

Solved javadoc complains:
SloccountTablePortlet.java
SloccountLanguageStatistics.java
SloccountParser.java
ClocFile.java
ClocFiles.java
ClocHeader.java
ClocReport.java
ClocTotal.java

Updated API for new Jenkins:
FileFinder.java

Added escape-by-default in all jelly files:
index.jelly
SloccountTablePortlet/portlet.jelly
SloccountTablePortlet/table.jelly
SloccountBuildAction/statistics.jelly
SloccountBuildAction/summary.jelly
SloccountProjectAction/floatingBox.jelly
SloccountProjectAction/jobMain.jelly
SloccountPublisher/config.jelly
SloccountResult/files.jelly
SloccountResult/folders.jelly
SloccountResult/index.jelly
SloccountResult/languages.jelly
SloccountResult/modules.jelly
tabview/css.jelly
tabview/distribution-graph.jelly
tabview/main.jelly

Added SloccountPublisher step supporting workflow (with jelly file and
tests)
steps/SloccountPublisherStep.java
SloccountPublisherStep/config.jelly
test/SloccountPublisherStepTest.java