### PR TITLE
Fix misplaced comment and line counters on the Folders view

### DIFF
--- a/src/main/resources/hudson/plugins/sloccount/SloccountResult/folders.jelly
+++ b/src/main/resources/hudson/plugins/sloccount/SloccountResult/folders.jelly
@@ -18,8 +18,8 @@
         <tr>
           <td class="pane"><a href="folderResult/${container.urlName}">${container.name}</a></td>
           <td class="pane number" data="${container.fileCount}">${container.fileCountString}</td>
-          <td class="pane number" data="${container.commentCount}">${container.commentCountString}</td>
           <td class="pane number" data="${container.lineCount}">${container.lineCountString}</td>
+          <td class="pane number" data="${container.commentCount}">${container.commentCountString}</td>
           <td class="pane" data="${container.lineCount}"><st:include page="/tabview/distribution-graph.jelly" /></td>
         </tr>
       </j:forEach>
@@ -28,8 +28,8 @@
       <tr class="sortbottom">
         <td class="pane-header">${%Total} ${cachedReport.folderCountString}</td>
         <td class="pane-header number" data="${cachedReport.fileCount}">${cachedReport.fileCountString}</td>
-        <td class="pane-header number" data="${cachedReport.commentCount}">${cachedReport.commentCountString}</td>
         <td class="pane-header number" data="${cachedReport.lineCount}">${cachedReport.lineCountString}</td>
+        <td class="pane-header number" data="${cachedReport.commentCount}">${cachedReport.commentCountString}</td>
         <td class="pane-header" data="0"> </td>
       </tr>
     </tfoot>


### PR DESCRIPTION
This change fixes the minor issue reported in ticket [JENKINS-37056](https://issues.jenkins-ci.org/browse/JENKINS-37056).

It is only a cosmetic change in the template file that renders the report for folders.