### PR TITLE
Add Java 11 tests to the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,12 @@
 #!/usr/bin/env groovy
+coreJdk11Version="2.164"
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "8", jenkins: coreJdk11Version, javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: coreJdk11Version, javaLevel: "8" ],
+  [ platform: "linux", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ]
+])


### PR DESCRIPTION
Resubmitting #54 from @batmat with my Admin superpowers so that we can see whether it actually works. Also bumped to 2.164

CC @jenkinsci/java11-support 
