### PR TITLE
Fix processing report files with Unicode in pathes.

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
+++ b/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
@@ -76,8 +76,9 @@ public class SloccountParser extends
     }
 
     private void parse(java.io.File file, SloccountReportInterface report) throws IOException {
-        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try {
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
             // Try cloc report file first, XML has precise structure
             ClocReport.parse(file).toSloccountReport(report, commentIsCode);
         } catch (JAXBException e) {
@@ -96,7 +97,9 @@ public class SloccountParser extends
                     in.close();
                 }
             }
-        }
+        } finally {
+    	    Thread.currentThread().setContextClassLoader(originalClassLoader);
+    	}
     }
 
     private void parse(Reader reader, SloccountReportInterface report) throws IOException {

--- a/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
+++ b/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
@@ -98,8 +98,8 @@ public class SloccountParser extends
                 }
             }
         } finally {
-    	    Thread.currentThread().setContextClassLoader(originalClassLoader);
-    	}
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
     }
 
     private void parse(Reader reader, SloccountReportInterface report) throws IOException {

--- a/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
+++ b/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
@@ -76,6 +76,7 @@ public class SloccountParser extends
     }
 
     private void parse(java.io.File file, SloccountReportInterface report) throws IOException {
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
         try {
             // Try cloc report file first, XML has precise structure
             ClocReport.parse(file).toSloccountReport(report, commentIsCode);

--- a/src/main/java/hudson/plugins/sloccount/model/cloc/ClocReport.java
+++ b/src/main/java/hudson/plugins/sloccount/model/cloc/ClocReport.java
@@ -10,6 +10,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.Serializable;
 
 /**
@@ -61,10 +63,15 @@ public class ClocReport implements Serializable {
      * @return the content of the parsed file in form of a report
      * @throws javax.xml.bind.JAXBException if a XML related error occurs
      */
-    public static ClocReport parse(File file) throws JAXBException {
+    public static ClocReport parse(File file) throws JAXBException, java.io.IOException {
         JAXBContext context = JAXBContext.newInstance(ClocReport.class);
         Unmarshaller unmarshaller = context.createUnmarshaller();
-        return (ClocReport) unmarshaller.unmarshal(file);
+        // Jenkins replaces ASCII symbols like colons found in filenames to Unicode.
+        // Using File() here causes converting Unicode symbols back to ASCII.
+        // Such files could not be found of course.
+        try (InputStream is = new FileInputStream(file)) {
+          return (ClocReport) unmarshaller.unmarshal(is);
+        }
     }
 
     /**


### PR DESCRIPTION
Jenkins replaces some ASCII symbols like colons with Unicode
storing builds data. Parsing reports letter when users open
'SLOCCount Results' window the plugin unable to retrieve
SLOC information - file was stored by path with Unicode.

It relates to JDK 8.
Using unmarshal(File f) indeed proceses not the File but a URL
based on its absolute path. When JDK tries to open connection it
calles ParseUtil.decode(url.getFile()) against our path containing
Unicode. This method converts Unicode back to ASCII. So we get
java.io.FileNotFoundException wrapped in javax.xml.bind.JAXBException,
which is ignored by the plugin. Using unmarshal(java.io.InputStream is)
soleves the issue due to JDK uses passed InputStream and all
described here above do not affect us.