### PR TITLE
Clean up `SloccountParser`

### DIFF
--- a/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
+++ b/src/main/java/hudson/plugins/sloccount/model/SloccountParser.java
@@ -76,9 +76,7 @@ public class SloccountParser extends
     }
 
     private void parse(java.io.File file, SloccountReportInterface report) throws IOException {
-        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
             // Try cloc report file first, XML has precise structure
             ClocReport.parse(file).toSloccountReport(report, commentIsCode);
         } catch (JAXBException e) {
@@ -97,8 +95,6 @@ public class SloccountParser extends
                     in.close();
                 }
             }
-        } finally {
-            Thread.currentThread().setContextClassLoader(originalClassLoader);
         }
     }
 


### PR DESCRIPTION
Amends #57 and #62. #57 applied the fix at a broad scope. #62 applied the same fix at a narrow scope. The fix is only needed in one scope, so let us keep #62 and undo #57 to keep the scope as limited as possible to make behavior easier to reason about.